### PR TITLE
WAR-1774/WAR-1694: Project with parallel suite(s) creates duplicate entries in execution summary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
       python: 2.7
     - os: linux
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_exec_summary.xml
+      python: 2.7
+    - os: linux
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes
       python: 2.7
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       python: 3.4
     - os: linux
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_exec_summary.xml
-      python: 2.7
+      python: 3.4
     - os: linux
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes
       python: 3.4

--- a/warrior/WarriorCore/iterative_parallel_testcase_driver.py
+++ b/warrior/WarriorCore/iterative_parallel_testcase_driver.py
@@ -77,7 +77,8 @@ def execute_iterative_parallel_testcases(system_list, testcase_list, suite_repos
     # parallel testcases generate multiple testcase junit result files
     # each files log the result for one testcase and not intergrated
     # update testsuite junit result file with individual testcase result files
-    update_ts_junit_resultfile(suite_repository['wt_junit_object'], tc_junit_list)
+    update_ts_junit_resultfile(suite_repository['wt_junit_object'],
+                               tc_junit_list, data_repository['wt_ts_timestamp'])
     testsuite_status = Utils.testcase_Utils.compute_status_using_impact(tc_status_list,
                                                                         tc_impact_list)
     return testsuite_status

--- a/warrior/WarriorCore/multiprocessing_utils.py
+++ b/warrior/WarriorCore/multiprocessing_utils.py
@@ -59,19 +59,25 @@ def get_results_from_queue(queue):
     return result_list
 
 
-def update_ts_junit_resultfile(ts_junit_obj, tc_junit_list):
+def update_ts_junit_resultfile(ts_junit_obj, tc_junit_list, ts_timestamp):
     """loop through tc_junit object and attach testcase result to testsuite
     Arguments:
     1. ts_junit_obj = target testsuite
     2. tc_junit_list = list of testcase junit objects
     """
-    for tc_junit_obj in tc_junit_list:
-        for tc in tc_junit_obj.root.iter('testcase'):
-            # append testcase result to testsuite
-            ts_junit_obj.root.find('testsuite').append(tc)
-            # update the count in testsuite attribute
-            ts_junit_obj.attrib = update_attribute(ts_junit_obj.root.find('testsuite').attrib,
-                                                   tc.attrib)
+
+    for master_ts in ts_junit_obj.root.iter('testsuite'):
+        # make sure we are modifying the correct testsuite
+        if master_ts.get('timestamp') == ts_timestamp:
+            for tc_junit_obj in tc_junit_list:
+                for ts_part in tc_junit_obj.root.iter('testsuite'):
+                    # make sure we are obtaining only the wanted testcases
+                    if ts_part.get('timestamp') == ts_timestamp:
+                        # add testcase element to testsuite, update count
+                        for tc in ts_part.iter('testcase'):
+                            master_ts.append(tc)
+                            master_ts.attrib = update_attribute(master_ts.attrib, ts_part.attrib)
+
     return ts_junit_obj
 
 
@@ -118,7 +124,7 @@ def update_tc_junit_resultfile(tc_junit_obj, kw_junit_list, tc_timestamp):
             for kw_junit_obj in kw_junit_list:
                 for tc_part in kw_junit_obj.root.iter('testcase'):
                     # make sure we are obtaining only the wanted keywords
-                    if (tc_part.get('timestamp') == tc_timestamp):
+                    if tc_part.get('timestamp') == tc_timestamp:
                         # add keyword element to testcase, add property result
                         # to properties, update count
                         for result in tc_part.find('properties').iter('property'):

--- a/warrior/WarriorCore/parallel_testcase_driver.py
+++ b/warrior/WarriorCore/parallel_testcase_driver.py
@@ -13,22 +13,20 @@ limitations under the License.
 
 #!/usr/bin/python
 
-"""This is  parallel testcase driver which is used to execute
-the testcases of a suite in parallel """
-
 import os
 import traceback
 from collections import OrderedDict
-
 
 from . import testcase_driver
 import Framework.Utils as Utils
 from Framework.Utils.print_Utils import print_error, print_debug
 from WarriorCore.multiprocessing_utils import create_and_start_process_with_queue, \
-get_results_from_queue, update_ts_junit_resultfile
+ get_results_from_queue, update_ts_junit_resultfile
 from WarriorCore import testsuite_utils
 
 
+"""This is  parallel testcase driver which is used to execute
+the testcases of a suite in parallel """
 
 
 def execute_parallel_testcases(testcase_list, suite_repository,
@@ -55,35 +53,40 @@ def execute_parallel_testcases(testcase_list, suite_repository,
         tc_runtype = testsuite_utils.get_runtype_from_xmlfile(testcase)
         tc_impact = Utils.testcase_Utils.get_impact_from_xmlfile(testcase)
         tc_context = Utils.testcase_Utils.get_context_from_xmlfile(testcase)
-        suite_step_data_file = testsuite_utils.get_data_file_at_suite_step(testcase, suite_repository)
-        tc_onError_action = Utils.xml_Utils.get_attributevalue_from_directchildnode(testcase, 'onError', 'action')
+        suite_step_data_file = testsuite_utils.get_data_file_at_suite_step(testcase,
+                                                                           suite_repository)
+        tc_onError_action = Utils.xml_Utils.get_attributevalue_from_directchildnode(testcase,
+                                                                                    'onError',
+                                                                                    'action')
         tc_onError_action = tc_onError_action if tc_onError_action else suite_error_action
         if suite_step_data_file is not None:
             data_file = Utils.file_Utils.getAbsPath(suite_step_data_file, testsuite_dir)
             data_repository[tc_path] = data_file
 
         data_repository['wt_tc_impact'] = tc_impact
-        
+
         # instead of using args_list, we need to use an ordered dict
         # for tc args because intially q will be none and 
         # we need to cange it after creating a new q
         # then we need to maintain the position of arguments
         # before calling the testcase driver main function.
-        
-        tc_args_dict = OrderedDict([("tc_path", tc_path),
-                                  ("data_repository", data_repository),
-                                  ("tc_context", tc_context),
-                                  ("tc_runtype", tc_runtype),
-                                  ("tc_parallel", tc_parallel),
-                                  ("auto_defects", auto_defects),
-                                  ("suite", suite),
-                                  ("tc_onError_action", tc_onError_action),
-                                  ("iter_ts_sys", iter_ts_sys),
-                                  ("output_q", output_q),
-                                  ("jiraproj", jiraproj)                                  
-                                  ])
 
-        process, jobs_list, output_q = create_and_start_process_with_queue(target_module, tc_args_dict, jobs_list, output_q)
+        tc_args_dict = OrderedDict([("tc_path", tc_path),
+                                    ("data_repository", data_repository),
+                                    ("tc_context", tc_context),
+                                    ("tc_runtype", tc_runtype),
+                                    ("tc_parallel", tc_parallel),
+                                    ("auto_defects", auto_defects),
+                                    ("suite", suite),
+                                    ("tc_onError_action", tc_onError_action),
+                                    ("iter_ts_sys", iter_ts_sys),
+                                    ("output_q", output_q),
+                                    ("jiraproj", jiraproj)
+                                    ])
+
+        process, jobs_list, output_q = create_and_start_process_with_queue(target_module,
+                                                                           tc_args_dict,
+                                                                           jobs_list, output_q)
 
     print_debug("process: {0}".format(process))
     for job in jobs_list:
@@ -95,7 +98,8 @@ def execute_parallel_testcases(testcase_list, suite_repository,
     tc_name_list = []
     tc_impact_list = []
     tc_duration_list = []
-    # Get the junit object of each testcase, extract the information from it and combine with testsuite junit object
+    # Get the junit object of each testcase, extract the information from it and
+    # combine with testsuite junit object
     tc_junit_list = []
 
     for result in result_list:
@@ -108,7 +112,9 @@ def execute_parallel_testcases(testcase_list, suite_repository,
     # parallel testcases generate multiple testcase junit result files
     # each files log the result for one testcase and not intergrated
     # update testsuite junit result file with individual testcase result files
-    data_repository['wt_junit_object'] = update_ts_junit_resultfile(data_repository['wt_junit_object'], tc_junit_list)
+    data_repository['wt_junit_object'] = update_ts_junit_resultfile(
+        data_repository['wt_junit_object'], tc_junit_list,
+        data_repository['wt_ts_timestamp'])
     testsuite_status = Utils.testcase_Utils.compute_status_using_impact(tc_status_list,
                                                                         tc_impact_list)
     return testsuite_status

--- a/wftests/warrior_tests/data/framework_tests/data_exec_summary.xml
+++ b/wftests/warrior_tests/data/framework_tests/data_exec_summary.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<systems>
+        <description/>
+        <system default="yes" name="sys1"/>
+        <system name="sys2"/>
+</systems>

--- a/wftests/warrior_tests/projects/pj_exec_summary.xml
+++ b/wftests/warrior_tests/projects/pj_exec_summary.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<Project>
+        <Details>
+                <Name>pj_exec_summary</Name>
+                <Title>Project to verify execution summary</Title>
+                <Engineer>Warrior_user</Engineer>
+                <State/>
+                <Date>02/28/2018</Date>
+                <Time>15:58:39</Time>
+                <default_onError action="next" value=""/>
+        </Details>
+        <Testsuites>
+                <Testsuite>
+                        <path>../suites/framework_tests/exec_summary/ts_parallel_tcs.xml</path>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <onError action="next" value=""/>
+                        <impact>impact</impact>
+                </Testsuite>
+                <Testsuite>
+                        <path>../suites/framework_tests/exec_summary/ts_sequential_tcs.xml</path>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <onError action="next" value=""/>
+                        <impact>impact</impact>
+                </Testsuite>
+        </Testsuites>
+</Project>

--- a/wftests/warrior_tests/suites/framework_tests/exec_summary/ts_parallel_tcs.xml
+++ b/wftests/warrior_tests/suites/framework_tests/exec_summary/ts_parallel_tcs.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_parallel_tcs</Name>
+                <Title>simple suite with parallel tc execution</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>02/28/2018</Date>
+                <Time>15:43:37</Time>
+                <type Max_Attempts="" Number_Attempts="" exectype="parallel_testcases"/>
+                <State/>
+                <default_onError action="next" value=""/>
+                <Resultsdir/>
+                <InputDataFile/>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_custom.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>parallel_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_custom.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_iterative.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>parallel_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_iterative.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/suites/framework_tests/exec_summary/ts_sequential_tcs.xml
+++ b/wftests/warrior_tests/suites/framework_tests/exec_summary/ts_sequential_tcs.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<TestSuite>
+        <Details>
+                <Name>ts_sequential_tcs</Name>
+                <Title>simple suite with sequential tc execution</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>02/28/2018</Date>
+                <Time>15:30:57</Time>
+                <type Max_Attempts="" Number_Attempts="" exectype="sequential_testcases"/>
+                <State/>
+                <default_onError action="next" value=""/>
+                <Resultsdir/>
+                <InputDataFile/>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Testcases>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_custom.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>parallel_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_custom.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_iterative.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>parallel_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+                <Testcase>
+                        <path>../../../testcases/framework_tests/exec_summary/tc_iterative.xml</path>
+                        <context>positive</context>
+                        <InputDataFile/>
+                        <runtype>sequential_keywords</runtype>
+                        <onError action="next" value=""/>
+                        <runmode type="Standard" value=""/>
+                        <Execute ExecType="Yes">
+                                <Rule Condition="" Condvalue="" Else="next" Elsevalue=""/>
+                        </Execute>
+                        <impact>impact</impact>
+                </Testcase>
+        </Testcases>
+</TestSuite>

--- a/wftests/warrior_tests/testcases/framework_tests/exec_summary/tc_custom.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/exec_summary/tc_custom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_custom</Name>
+                <Title>Custom testcase with pass and fail keywords</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>2018-02-28</Date>
+                <Time>15:37</Time>
+                <State/>
+                <InputDataFile>../../../data/framework_tests/data_exec_summary.xml</InputDataFile>
+                <Datatype>Custom</Datatype>
+                <default_onError action="next"/>
+                <Logsdir/>
+                <Resultsdir/>
+                <ExpectedResults/>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="local_data_test" TS="1" draft="no">
+                        <Arguments>
+                                <argument name="desired_status" value="pass"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>simple pass step</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="ci_regression_driver" Keyword="local_data_test" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="desired_status" value="fail"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>simple fail step</Description>
+                        <iteration_type type="Standard"/>
+                        <context>negative</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+        </Steps>
+</Testcase>

--- a/wftests/warrior_tests/testcases/framework_tests/exec_summary/tc_iterative.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/exec_summary/tc_iterative.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<Testcase>
+        <Details>
+                <Name>tc_iterative</Name>
+                <Title>Iterative testcase with pass and fail keywords</Title>
+                <Engineer>Warrior_user</Engineer>
+                <Date>2018-02-28</Date>
+                <Time>15:24</Time>
+                <State/>
+                <InputDataFile>../../../data/framework_tests/data_exec_summary.xml</InputDataFile>
+                <Datatype>Iterative</Datatype>
+                <default_onError action="next"/>
+                <Logsdir/>
+                <Resultsdir/>
+                <ExpectedResults/>
+        </Details>
+        <Requirements>
+                <Requirement/>
+        </Requirements>
+        <Steps>
+                <step Driver="ci_regression_driver" Keyword="local_data_test" TS="1" draft="no">
+                        <Arguments>
+                                <argument name="desired_status" value="pass"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>simple pass step</Description>
+                        <iteration_type type="Standard"/>
+                        <context>positive</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+                <step Driver="ci_regression_driver" Keyword="local_data_test" TS="2" draft="no">
+                        <Arguments>
+                                <argument name="desired_status" value="fail"/>
+                        </Arguments>
+                        <Execute ExecType="Yes"/>
+                        <onError action="next"/>
+                        <Description>simple fail step</Description>
+                        <iteration_type type="Standard"/>
+                        <context>negative</context>
+                        <impact>impact</impact>
+                        <runmode type="Standard" value=""/>
+                </step>
+        </Steps>
+</Testcase>


### PR DESCRIPTION
Expectations of Parallel testcases execution,

Separate child process will be created for executing each testcase and copy of master junit object will be sent across all processes.
Each process will add the result in the corresponding junit object.
After the completion of all processes, those junit objects will be collected to fetch all the newly added results.
Warrior will add those results into the original master junit object.
Issue: Filtration is not happening at step3, Warrior adds all the existing results into original master junit object.

Solution: Use Testsuite timestamp to filter out the newly added results so that there will not be any duplicate entries.

Test instructions and regression logs are in Jira ticket.

PR for warriorframework repo : warriorframework/warriorframework#394