### PR TITLE
WAR-1781: Unable to check api_response with regex pattern using verify_response keyword

### DIFF
--- a/katana/native/settings/settings.py
+++ b/katana/native/settings/settings.py
@@ -60,7 +60,7 @@ class Settings:
             elem_file.remove(def_dir_xml_obj)
             val = xmltodict.unparse(w_settings_data, pretty=True)
             elem_file.insert(0, xml_controler.fromstring(val))
-            with open(w_settings, 'w') as f:
+            with open(w_settings, 'wb') as f:
                 f.write(xml_controler.tostring(elem_file))
             with open(json_file, 'w') as f:
                 f.write(json.dumps(returned_json[0], indent=4, separators=(',', ': ')))

--- a/warrior/Actions/RestActions/rest_actions.py
+++ b/warrior/Actions/RestActions/rest_actions.py
@@ -3000,7 +3000,15 @@ class RestActions(object):
 
                 4. expected_response_type: The type of expected response
                     Can be xml or json or text
-                
+                    For jsonpath & xpath comparison_modes, verify status will
+                    be marked as pass if anyone the below operations is successful:
+                        1. Equality match: Check if the expected response is
+                        equal to API response
+                        2. Regex search: Check if the expected
+                        response(pattern) is in API response
+                    Use 'regex=expression' as comparison_mode to support
+                    python regular expression for text response.
+
                 5. comparison_mode:
                    This is the mode in which you wish to compare
                    The supported comparison modes are

--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -13,7 +13,8 @@ limitations under the License.
 
 """API for json related operations """
 import json
-from Framework.Utils.print_Utils import print_info, print_exception, print_error
+import re
+from Framework.Utils.print_Utils import print_info, print_exception, print_error, print_warning
 from Framework.Utils.testcase_Utils import pNote,pSubStep
 import difflib
 
@@ -247,16 +248,27 @@ class JsonUtils(object):
         status = True
         json_response = json.loads(response)
         for index, jsonpath in enumerate(list_of_jsonpath):
-            json_path = jsonpath.strip("json=")
+            json_path = jsonpath.strip("jsonpath=")
             value = self.get_value_for_nested_key(json_response, json_path)
-            if value != list_of_expected_api_responses[index]:
+            # Equality_match: Check if the expected response is equal to API response
+            match = True if value == list_of_expected_api_responses[index] else False
+            # Perform Regex_search if equality match fails
+            if match is False:
+                try:
+                    # Regex_search: Check if the expected response pattern is in API response
+                    match = re.search(list_of_expected_api_responses[index], value)
+                except Exception:
+                    print_warning("Python regex search failed, invalid "
+                                  "expected_response_pattern '{}' is "
+                                  "provided".format(list_of_expected_api_responses[index]))
+            if not match:
                 status = False
-                print_error("For the given {0} the expected response value is"
-                            " {1} but the actual response"
-                            " value is {2}".format(jsonpath,
-                            list_of_expected_api_responses[index], value))
+                print_error("For the given '{0}' the expected response value is '{1}'. "
+                            "It doesn't match or available in the actual response value "
+                            "'{2}'".format(jsonpath, list_of_expected_api_responses[index],
+                                           value))
         return status
-    
+
     def get_value_for_nested_key(self, json_response, json_path):
         """
             Returns the value of the nested key in the dictionary

--- a/warrior/Framework/ClassUtils/rest_utils_class.py
+++ b/warrior/Framework/ClassUtils/rest_utils_class.py
@@ -334,6 +334,8 @@ class WRest(object):
                 if "xml" in response.headers['Content-Type']:
                     status = Utils.xml_Utils.compare_xml_using_xpath(extracted_response, path_list, responses_list)
                 elif "json" in response.headers['Content-Type']:
+                    if isinstance(extracted_response, bytes):
+                        extracted_response = extracted_response.decode('utf-8')
                     status = self.json_utils.compare_json_using_jsonpath(extracted_response, path_list, responses_list)
                 else:
                     if isinstance(extracted_response, bytes):

--- a/warrior/Framework/ClassUtils/rest_utils_class.py
+++ b/warrior/Framework/ClassUtils/rest_utils_class.py
@@ -336,6 +336,8 @@ class WRest(object):
                 elif "json" in response.headers['Content-Type']:
                     status = self.json_utils.compare_json_using_jsonpath(extracted_response, path_list, responses_list)
                 else:
+                    if isinstance(extracted_response, bytes):
+                        extracted_response = extracted_response.decode('utf-8')
                     status = Utils.string_Utils.compare_string_using_regex(extracted_response, path_list)
             else:
                 print_error("Please provide the values for comparison_mode and expected_api_response")

--- a/warrior/Framework/ClassUtils/rest_utils_class.py
+++ b/warrior/Framework/ClassUtils/rest_utils_class.py
@@ -498,6 +498,7 @@ class WRest(object):
 
     @staticmethod
     def get_output_response(api_response):
+        """ Convert the api_response.text in desired format(xml/json/text) """
         if api_response is not None:
             try:
                 output_response = parseString("".join(api_response.text))

--- a/warrior/Framework/Utils/xml_Utils.py
+++ b/warrior/Framework/Utils/xml_Utils.py
@@ -16,6 +16,7 @@ import sys
 import difflib
 import os
 from io import IOBase
+import re
 
 from . import file_Utils
 import os.path
@@ -152,7 +153,6 @@ def create_comment_element(text):
     creates and returns a xml comment element
     """
     elem = ElementTree.Comment(text)
-    
     return elem
 
 def get_matching_firstlevel_children_from_root(filename, child_tag):
@@ -993,12 +993,23 @@ def compare_xml_using_xpath(response, list_of_xpath, list_of_expected_api_respon
         for index, xpath_pattern in enumerate(list_of_xpath):
             xpath = xpath_pattern.strip("xpath=")
             value = getValuebyTagFromStringWithXpath(response, xpath, None)
-            if value != list_of_expected_api_responses[index]:
+            # Equality_match: Check if the expected response is equal to API response
+            match = True if value == list_of_expected_api_responses[index] else False
+            # Perform Regex_search if equality match fails
+            if match is False:
+                try:
+                    # Regex_search: Check if the expected response pattern is in API response
+                    match = re.search(list_of_expected_api_responses[index], value)
+                except Exception:
+                    print_warning("Python regex search failed, invalid "
+                                  "expected_response_pattern '{}' is "
+                                  "provided".format(list_of_expected_api_responses[index]))
+            if not match:
                 status = False
-                print_error("For the given {0} the expected response value is"
-                            " {1} but the actual response"
-                            " value is {2}".format(xpath_pattern,
-                            list_of_expected_api_responses[index], value))
+                print_error("For the given '{0}' the expected response value is '{1}'. "
+                            "It doesn't match or available in the actual response value "
+                            "'{2}'".format(xpath_pattern, list_of_expected_api_responses[index],
+                                           value))
     return status
 
 def list_path_responses_datafile(datafile, system_name):
@@ -1016,31 +1027,3 @@ def list_path_responses_datafile(datafile, system_name):
         "./*[@name='"+system_name+"']/expected_api_response/*")
     responses_list = [x.text for x in resp_element_list]
     return path_list, responses_list
-
-def del_tag_from_element(ele, tag):
-    """
-        Delete a subelement with specific tag from an xml element object
-        return the deleted subelement if pass
-        return False if subelement not found
-    """
-    if ele.find(tag) is not None:
-        ele.remove(ele.find(tag))
-        return ele
-    else:
-        print_warning("cannot found {0} in element".format(str(tag)))
-    return False
-
-def safe_subelement(parent, tagname, text="", **kwargs):
-    """
-        create or overwrite a child element under the parent
-    """
-    if parent.find(tagname) is not None:
-        # Overwrite the child
-        ele = parent.find(tagname)
-        ele.text = text
-        ele.attrib = kwargs
-    else:
-        ele = ElementTree.SubElement(parent, tagname)
-        ele.text = text
-        ele.attrib = kwargs
-    return ele

--- a/warrior/Framework/Utils/xml_Utils.py
+++ b/warrior/Framework/Utils/xml_Utils.py
@@ -557,7 +557,7 @@ def getChildElementWithSpecificXpath(start, xpath):
     xpath = a valid xml path value as supported by python, refer https://docs.python.org/2/library/xml.etree.elementtree.html
     """
     node = False
-    if isinstance(start, (file, str)):
+    if isinstance(start, (IOBase, str)):
         # check if file exist here
         if file_Utils.fileExists(start):
             node = ElementTree.parse(start).getroot()

--- a/wftests/ci/custom_rules.py
+++ b/wftests/ci/custom_rules.py
@@ -43,11 +43,12 @@ def func_check(node, kw=False):
         elif child != node and isinstance(child, ast.ClassDef):
             tmp_status = class_check(child, kw)
             status &= tmp_status
-        elif 'war_print_class.py' not in sys.argv[1] and isinstance(child, ast.Print):
+        elif 'war_print_class.py' not in sys.argv[1] and hasattr(child, "value") and\
+            hasattr(child.value, "func") and hasattr(child.value.func, "id") and child.value.func.id == "print":
             # check for print statement
             status = False
             print("Please use print_Utils instead of print in {}: {}".format(
-                                                    sys.argv[1], child.lineno))
+                sys.argv[1], child.lineno))
         elif isinstance(child, ast.Return):
             # check for return statement
             have_return = True

--- a/wftests/ci/pylint_checker.py
+++ b/wftests/ci/pylint_checker.py
@@ -90,7 +90,7 @@ def custom_rules(file_list):
         try:
             output = subprocess.check_output('python3 wftests/ci/custom_rules.py {}'.format(fi), shell=True).decode("utf-8")
         except subprocess.CalledProcessError as e:
-            output = e.output
+            output = e.output.decode("utf-8")
             status = False
 
         print(output)

--- a/wftests/warrior_tests/suites/rest_functional_tests/rest_json_test_Suite.xml
+++ b/wftests/warrior_tests/suites/rest_functional_tests/rest_json_test_Suite.xml
@@ -33,6 +33,12 @@
 			<onError action="next"/>
 			<impact>impact</impact>
 		</Testcase>
-		
+		<Testcase>
+			<path>../../testcases/rest_functional_tests/tc_rest_verify_content_response.xml</path>
+			<context>positive</context>
+			<runtype>sequential_keywords</runtype>
+			<onError action="next"/>
+			<impact>impact</impact>
+		</Testcase>
 	</Testcases>
 </TestSuite>

--- a/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
+++ b/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
@@ -68,7 +68,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="4">
+		<step Driver="rest_driver" Keyword="verify_response" TS="5">
 			<Arguments>
 				<argument name="system_name" value="http_bin_2"/>
 				<argument name="expected_api_response" value="Date of publication"/>
@@ -82,7 +82,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="perform_http_get" TS="5">
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="6">
 			<Arguments>
 				<argument name="system_name" value="http_bin_3"/>
 				<argument name="url" value="http://httpbin.org/robots.txt"/>
@@ -94,7 +94,7 @@
 			<context>positive</context>
 			<impact>impact</impact>
 		</step>
-		<step Driver="rest_driver" Keyword="verify_response" TS="6">
+		<step Driver="rest_driver" Keyword="verify_response" TS="7">
 			<Arguments>
 				<argument name="system_name" value="http_bin_3"/>
 				<argument name="expected_api_response" value=""/>
@@ -106,6 +106,97 @@
 			<Description>This step verifies the API response with the expected API response</Description>
 			<Execute ExecType="Yes"/>
 			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="8">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="url" value="http://httpbin.org/response-headers?key1=5&amp;key2=[1.2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step tests the GET capability of REST</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="9">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[4-7]"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key1"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Pass)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="10">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[6-10]"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key1"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="11">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[1.2"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Equality check with special chars - Pass)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="12">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="[1."/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Equality check with special chars - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="13">
+			<Arguments>
+				<argument name="system_name" value="http_bin_2"/>
+				<argument name="expected_api_response" value="Date.+of pub.*on"/>
+				<argument name="expected_response_type" value="xml"/>
+				<argument name="request_id" value="123"/>
+				<argument name="comparison_mode" value="xpath=/*/@date"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Pass)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="14">
+			<Arguments>
+				<argument name="system_name" value="http_bin_2"/>
+				<argument name="expected_api_response" value="Date.+of pub.?on"/>
+				<argument name="expected_response_type" value="xml"/>
+				<argument name="request_id" value="123"/>
+				<argument name="comparison_mode" value="xpath=/*/@date"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Fail)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
 			<impact>impact</impact>
 		</step>
 	</Steps>


### PR DESCRIPTION
Code changes:

Add regex verification support for jsonpath/xmlpath' comparison modes in 'verify_response' rest kw
Fix a bug in jsonpath comparison mode verification
(more details in WAR-1781/WAR-1674)
Execute 'wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml' to verify the fix. Regression logs are in WAR-1781.

WAR-1756 is raised to improve pylint score in rest_actions.py

PR for warriorframework repo : warriorframework/warriorframework#381