### PR TITLE
WAR-1794 Improve Travis job run time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
       addons:
         firefox: "46.0"
         chrome: stable
-    - sudo: required
-      dist: trusty
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes
-      addons:
-        firefox: "46.0"
-        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -38,7 +32,7 @@ install:
   - if [[ ${INSTALL} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
       pip3 install pexpect==4.2 ;
       pip3 install requests==2.9.1 ;
-      pip3 install selenium==2.53.0 ;
+      pip3 install selenium==3.8.0 ;
       pip3 install lxml==3.3.3 ;
       pip3 install paramiko==1.16.0 ;
       pip3 install pysnmp==4.3.2 ;
@@ -49,9 +43,6 @@ install:
       unzip chromedriver_linux64.zip;
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;
-    fi
-  - if [[ ${SELENIUM_3} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
-      pip3 install selenium==3.8 ;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
       addons:
         firefox: "46.0"
         chrome: stable
+    - sudo: required
+      dist: trusty
+      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes SELENIUM_3=yes
+      addons:
+        firefox: "46.0"
+        chrome: stable
     - sudo: false
       dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
@@ -44,6 +50,9 @@ install:
       chmod +x chromedriver;
       mv chromedriver ~/bin/chromedriver;
     fi
+  - if [[ ${SELENIUM_3} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
+      pip3 install selenium==3.8 ;
+    fi
 
 script:
   - if [[ -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
@@ -54,10 +63,6 @@ script:
       python3 ./warrior/Warrior ./wftests/warrior_tests/projects/pj_framework_tests.xml ./wftests/warrior_tests/projects/pj_glob.xml ./wftests/warrior_tests/projects/pj_rest.xml ./wftests/warrior_tests/projects/pj_retry.xml ./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml ;
     elif [[ ${TESTFILES_2} = "yes" ]]; then
       python3 ./warrior/Warrior ./wftests/warrior_tests/projects/pj_cond_var.xml ./wftests/warrior_tests/projects/pj_iterative_execution.xml ./wftests/warrior_tests/projects/pj_parallel_execution.xml ./wftests/warrior_tests/projects/pj_parallel_execution_2.xml ;
-    elif [[ ${SELENIUM} = "yes" ]]; then
-      python3 ./warrior/Warrior $TESTFILE ;
-      pip3 install selenium==3.8 ;
-      python3 ./warrior/Warrior $TESTFILE ;
     else
       python3 ./warrior/Warrior $TESTFILE ;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,68 @@
 language: python
+python: 3.4
 
 matrix:
   include:
-    - os: linux
+    - sudo: false
+      dist: trusty
       env: INSTALL=no TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml
-      python: 3.4
-    - os: linux
+    - sudo: false
+      dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/ci/pylint.sh PYLINT=yes
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_iterative_execution.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_cond_var.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_glob.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_rest.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_retry.xml
-      python: 3.4
-    - os: linux
-      env: INSTALL=yes TESTFILE=./wftests/warrior_tests/projects/pj_parallel_execution_2.xml
-      python: 3.4
-    - os: linux
+    - sudo: false
+      dist: trusty
+      env: INSTALL=yes TESTFILES_1=yes
+    - sudo: false
+      dist: trusty
+      env: INSTALL=yes TESTFILES_2=yes
+    - sudo: required
+      dist: trusty
       env: INSTALL=yes TESTFILE=./wftests/warrior_tests/testcases/selenium_tests/tc_selenium_headless.xml SELENIUM=yes
-      python: 3.4
       addons:
         firefox: "46.0"
-    - os: linux
-      env: INSTALL=no  TESTFILE=./wftests/warrior_tests/projects/pj_common_actions.xml COPILOT=yes
-      python: 3.4
-install:
-    - if [ ${COPILOT} = "yes" ]; then
-        python setup.py install ;
-      fi
+        chrome: stable
+    - sudo: false
+      dist: trusty
+      env: INSTALL=no TESTFILE=./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml COPILOT=yes
 
-    - if [ ${INSTALL} = "yes" ]; then
-        pip3 install pexpect==4.2 ;
-        pip3 install requests==2.9.1 ;
-        pip3 install selenium==3.8.0 ;
-        pip3 install lxml==3.3.3 ;
-        pip3 install paramiko==1.16.0 ;
-        pip3 install pysnmp==4.3.2 ;
-      fi
-    - if [ ${SELENIUM} = "yes" ]; then
-        pip3 install pyvirtualdisplay==0.2.1 ;
-        sudo apt-get install xvfb ;
-        wget https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip;
-        unzip chromedriver_linux64.zip;
-        chmod +x chromedriver;
-        sudo mv chromedriver /usr/local/bin/;
-      fi
+install:
+  - if [[ ${COPILOT} = "yes" ]]; then
+      python3 setup.py install ;
+    fi
+  - if [[ ${INSTALL} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
+      pip3 install pexpect==4.2 ;
+      pip3 install requests==2.9.1 ;
+      pip3 install selenium==2.53.0 ;
+      pip3 install lxml==3.3.3 ;
+      pip3 install paramiko==1.16.0 ;
+      pip3 install pysnmp==4.3.2 ;
+    fi
+  - if [[ ${SELENIUM} = "yes" ]] && [[ ! -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
+      pip3 install pyvirtualdisplay==0.2.1 ;
+      wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip;
+      unzip chromedriver_linux64.zip;
+      chmod +x chromedriver;
+      mv chromedriver ~/bin/chromedriver;
+    fi
 
 script:
-    - if [ ${PYLINT} = "yes" ]; then
-        $TESTFILE ;
-      else
-        python3 ./warrior/Warrior $TESTFILE ;
-      fi
+  - if [[ -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
+      python3 ./warrior/Warrior ./wftests/warrior_tests/testcases/framework_tests/cond_var/pass.xml ;
+    elif [[ ${PYLINT} = "yes" ]]; then
+      $TESTFILE ;
+    elif [[ ${TESTFILES_1} = "yes" ]]; then
+      python3 ./warrior/Warrior ./wftests/warrior_tests/projects/pj_framework_tests.xml ./wftests/warrior_tests/projects/pj_glob.xml ./wftests/warrior_tests/projects/pj_rest.xml ./wftests/warrior_tests/projects/pj_retry.xml ./wftests/warrior_tests/projects/pj_runmode_retry_at_suite_level_at_project_file.xml ;
+    elif [[ ${TESTFILES_2} = "yes" ]]; then
+      python3 ./warrior/Warrior ./wftests/warrior_tests/projects/pj_cond_var.xml ./wftests/warrior_tests/projects/pj_iterative_execution.xml ./wftests/warrior_tests/projects/pj_parallel_execution.xml ./wftests/warrior_tests/projects/pj_parallel_execution_2.xml ;
+    elif [[ ${SELENIUM} = "yes" ]]; then
+      python3 ./warrior/Warrior $TESTFILE ;
+      pip3 install selenium==3.8 ;
+      python3 ./warrior/Warrior $TESTFILE ;
+    else
+      python3 ./warrior/Warrior $TESTFILE ;
+    fi
+
 after_success:
-  - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)
+  - if [[ ${COPILOT} = "yes" ]]; then
+      bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload);
+    fi


### PR DESCRIPTION
1. Move all test except selenium from vm to docker container (using sudo: false setting) to decrease test load time
2. Pack projects together in 2 containers to balance setup time and runtime
3. Make branch build runs simple TC only since branch build is only for blackduck scanning (no duplicate test run)

Selenium test has to run on vm as chrome has permission issue with chromedriver and selenium on non-root environment