### PR TITLE
WAR-1807 : Project execution mail subject reflected as NONE even though the project is passed

### DIFF
--- a/warrior/Actions/CiRegressionActions/ci_regression_actions.py
+++ b/warrior/Actions/CiRegressionActions/ci_regression_actions.py
@@ -378,7 +378,7 @@ class CIregressionActions(object):
             # this block checks if dict_value is dict type
             pNote(err_msg.format(dict_value, "dict", type(dict_value)), "error")
             status = False
-        if type(file_value) is not file:
+        if type(file_value) is not IOBase:
             # this block checks if file_value is file type
             pNote(err_msg.format(file_value, "file", type(file_value)), "error")
             status = False

--- a/warrior/Actions/CiRegressionActions/ci_regression_actions.py
+++ b/warrior/Actions/CiRegressionActions/ci_regression_actions.py
@@ -378,8 +378,8 @@ class CIregressionActions(object):
             # this block checks if dict_value is dict type
             pNote(err_msg.format(dict_value, "dict", type(dict_value)), "error")
             status = False
-        if type(file_value) is not IOBase:
-            # this block checks if file_value is file type
+        if not isinstance(file_value, IOBase):
+            # this block checks if file_value is filetype
             pNote(err_msg.format(file_value, "file", type(file_value)), "error")
             status = False
         else:

--- a/warrior/Framework/Utils/email_utils.py
+++ b/warrior/Framework/Utils/email_utils.py
@@ -167,7 +167,7 @@ def compose_send_email(exec_type, abs_filepath, logs_dir, results_dir, result,
                 (3) every_failure
     """
     resultconverted = {"True": "Pass", "False": "Fail", "ERROR": "Error",
-                       "EXCEPTION": "Exception"}.get(str(result))
+                       "EXCEPTION": "Exception", "RAN": "Ran"}.get(str(result))
     subject = str(resultconverted)+": "+file_Utils.getFileName(abs_filepath)
     body = construct_mail_body(exec_type, abs_filepath, logs_dir, results_dir)
     report_attachment = results_dir + os.sep + \

--- a/warrior/WarriorCore/Classes/testcase_utils_class.py
+++ b/warrior/WarriorCore/Classes/testcase_utils_class.py
@@ -528,6 +528,8 @@ class TestcaseUtils(object):
             status = 'ERROR'
         elif 'ERROR' not in result and False in result:
             status = False
+        elif 'RAN' in result:
+            status = 'RAN'
         else:
             status = True
         return status

--- a/warrior/WarriorCore/Classes/testcase_utils_class.py
+++ b/warrior/WarriorCore/Classes/testcase_utils_class.py
@@ -526,7 +526,7 @@ class TestcaseUtils(object):
             result.append(value)
         if 'ERROR' in result:
             status = 'ERROR'
-        elif 'ERROR' not in result and False in result:
+        elif False in result:
             status = False
         elif 'RAN' in result:
             status = 'RAN'

--- a/warrior/WarriorCore/Classes/testcase_utils_class.py
+++ b/warrior/WarriorCore/Classes/testcase_utils_class.py
@@ -509,22 +509,27 @@ class TestcaseUtils(object):
     @staticmethod
     def compute_status_using_impact(input_status_list, input_impact_list, status=True):
         """Computes the status from the list of input status and input impact """
-        status = True
+        value = True
+        result = []
         for i in range(0, len(input_status_list)):
             input_status = input_status_list[i]
             input_impact = input_impact_list[i]
             if str(input_impact).upper() == 'IMPACT' and input_status != None:
                 if str(input_status).upper() == 'ERROR' or str(input_status).upper() == 'EXCEPTION':
-                    #input_status_list[i] = False
-                    status = 'ERROR'
-                    break
+                    value = 'ERROR'
                 elif str(input_status).upper() == 'RAN':
-                    status = 'RAN'
-                elif input_status == False:
-                    status = False 
-                    break
+                    value = 'RAN'
+                elif input_status is False:
+                    value = False
                 elif input_status is True:
-                    status = True 
+                    value = True
+            result.append(value)
+        if 'ERROR' in result:
+            status = 'ERROR'
+        elif 'ERROR' not in result and False in result:
+            status = False
+        else:
+            status = True
         return status
 
     @staticmethod

--- a/warrior/WarriorCore/project_driver.py
+++ b/warrior/WarriorCore/project_driver.py
@@ -30,11 +30,6 @@ from WarriorCore import common_execution_utils, sequential_testsuite_driver, \
 Warrior testsuites """
 
 
-# !/usr/bin/python
-"""This the project driver that executes a collections of
-Warrior testsuites """
-
-
 def get_project_details(project_filepath, res_startdir, logs_startdir, data_repository):
     """Gets all details of the Project from its xml file"""
 
@@ -273,7 +268,7 @@ def execute_project(project_filepath, auto_defects, jiraproj, res_startdir, logs
     hms = Utils.datetime_utils.get_hms_for_seconds(project_duration)
     print_info("Project duration= {0}".format(hms))
 
-    project_status = report_project_result(project_status, project_repository)
+    report_project_result(project_status, project_repository)
     pj_junit_object.update_attr("status", str(project_status), "pj", project_start_time)
     pj_junit_object.update_attr("time", str(project_duration), "pj", project_start_time)
 
@@ -310,7 +305,7 @@ def report_project_result(project_status, project_repository):
     """
 
     project_status = {'TRUE': 'PASS', 'FALSE': 'FAIL',
-                      'ERROR': 'ERROR', 'EXCEPTION': 'ERROR'}.\
+                      'ERROR': 'ERROR', 'EXCEPTION': 'ERROR', 'RAN': 'RAN'}.\
         get(str(project_status).upper())
 
     print_info("Project:{0}  STATUS:{1}".format(project_repository['project_name'],

--- a/warrior/WarriorCore/sequential_testcase_driver.py
+++ b/warrior/WarriorCore/sequential_testcase_driver.py
@@ -240,7 +240,7 @@ def execute_sequential_testcases(testcase_list, suite_repository,
         tc_duration_list.append(tc_duration)
 
         string_status = {"TRUE": "PASS", "FALSE": "FAIL", "ERROR": "ERROR",
-                         "SKIP": "SKIP"}
+                         "SKIP": "SKIP", "RAN": "RAN"}
 
         if str(tc_status).upper() in list(string_status.keys()):
             data_repository['testcase_%d_result' % tests] = string_status[

--- a/warrior/WarriorCore/sequential_testsuite_driver.py
+++ b/warrior/WarriorCore/sequential_testsuite_driver.py
@@ -136,7 +136,8 @@ def execute_sequential_testsuites(testsuite_list, project_repository,
                                     data_repository['wt_ts_timestamp'])
         pj_junit_object.update_attr("onerror", onerror, "ts", data_repository['wt_ts_timestamp'])
 
-        string_status = {"TRUE": "PASS", "FALSE": "FAIL", "ERROR": "ERROR", "SKIP": "SKIP"}
+        string_status = {"TRUE": "PASS", "FALSE": "FAIL", "ERROR": "ERROR",
+                         "SKIP": "SKIP", "RAN": "RAN"}
 
         if str(testsuite_status).upper() in list(string_status.keys()):
             data_repository['testsuite_{}_result'.format(suite_cntr)] = \

--- a/warrior/WarriorCore/testsuite_utils.py
+++ b/warrior/WarriorCore/testsuite_utils.py
@@ -11,216 +11,233 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-import xml.etree.ElementTree as ET
-from Framework.Utils import file_Utils, xml_Utils, config_Utils
 import datetime
-from Framework.Utils.print_Utils import print_debug, print_info, print_error, print_warning
+import xml.etree.ElementTree as ET
+from Framework.Utils import xml_Utils, config_Utils
+from Framework.Utils.print_Utils import print_info, print_error, print_warning
 
-root = None
-currentPointer = None
-currentTestSuitePointer = None
-currentPropertiesPointer = None
-currentTestCasePointer= None
+ROOT = None
+CURRENT_POINTER = None
+CURRENT_TESTSUITE_POINTER = None
+CURRENT_PROPERTIES_POINTER = None
+CURRENT_TESTCASE_POINTER = None
 
-gTestSuite = {}
-gTestSuiteLoop = 0
+G_TESTSUITE = {}
+G_TESTSUITE_LOOP = 0
 
-gProperties = {}
-gPropertiesLoop = 0
+G_PROPERTIES = {}
+G_PROPERTIES_LOOP = 0
 
-gProperty = {}
-gPropertyLoop = 0
+G_PROPERTY = {}
+G_PROPERTY_LOOP = 0
 
-gTestCase = {}
-gTestCaseLoop = 0
+G_TESTCASE = {}
+G_TESTCASE_LOOP = 0
 
 
 def printOutput():
     """ Prints the dump of the xml object to the file specified.
-    This function can be used for debugging purpose and its called at the end of the functional calls.
-        
+    This function can be used for debugging purpose and its called at the end of
+    the functional calls.
+
     Arguments:
         resultfile = Result File
-        
+
     Returns:
         None
     """
-    global root
-    
+    global ROOT
+
     resultfile = config_Utils.junit_resultfile
-    tree = ET.ElementTree(root)
+    tree = ET.ElementTree(ROOT)
     # tree.write(resultfile)
 
 
 def pSuite_root(resultfile):
-    global root
-    global currentPointer
-    
-    root=ET.Element("testsuites")
-    currentPointer = root
+    """ Get the root element and assign it to current pointer"""
+    global ROOT
+    global CURRENT_POINTER
+
+    ROOT = ET.Element("testsuites")
+    CURRENT_POINTER = ROOT
     printOutput()
 
 
-def pSuite_testsuite(resultfile, name, errors, skipped, tests, failures, time, timestamp):   
-    global root
-    global currentPointer
-    global currentTestSuitePointer
-    global currentPropertiesPointer
-    global gTestSuite
-    global gTestSuiteLoop
-    global gProperties
-    global gPropertiesLoop
-    
-    gTestSuiteLoop = gTestSuiteLoop+1   
-    gTestSuite[gTestSuiteLoop] = ET.SubElement(currentPointer,"testsuite")
+def pSuite_testsuite(resultfile, name, errors, skipped, tests, failures, time, timestamp):
+    """ set the attributes of test suite """
+    global ROOT
+    global CURRENT_POINTER
+    global CURRENT_TESTSUITE_POINTER
+    global CURRENT_PROPERTIES_POINTER
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+    global G_PROPERTIES
+    global G_PROPERTIES_LOOP
 
-    gTestSuite[gTestSuiteLoop].set('name',name)
-    gTestSuite[gTestSuiteLoop].set('errors',errors)
-    gTestSuite[gTestSuiteLoop].set('skipped',skipped)
-    gTestSuite[gTestSuiteLoop].set('tests',tests)
-    gTestSuite[gTestSuiteLoop].set('failures',failures)
-    gTestSuite[gTestSuiteLoop].set('time',time)
-    #print "setting time to", time
-    gTestSuite[gTestSuiteLoop].set('timestamp',timestamp)
-    currentTestSuitePointer = gTestSuite[gTestSuiteLoop]
-    
-    gPropertiesLoop = gPropertiesLoop+1
-    gProperties[gPropertiesLoop] = ET.SubElement(currentTestSuitePointer,"properties")
-    gProperties[gPropertiesLoop].text = ""
-    currentPropertiesPointer = gProperties[gPropertiesLoop]
+    G_TESTSUITE_LOOP = G_TESTSUITE_LOOP+1
+    G_TESTSUITE[G_TESTSUITE_LOOP] = ET.SubElement(CURRENT_POINTER, "testsuite")
+
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('name', name)
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('errors', errors)
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('skipped', skipped)
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('tests', tests)
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('failures', failures)
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('time', time)
+    # print "setting time to", time
+    G_TESTSUITE[G_TESTSUITE_LOOP].set('timestamp', timestamp)
+    CURRENT_TESTSUITE_POINTER = G_TESTSUITE[G_TESTSUITE_LOOP]
+
+    G_PROPERTIES_LOOP = G_PROPERTIES_LOOP+1
+    G_PROPERTIES[G_PROPERTIES_LOOP] = ET.SubElement(CURRENT_TESTSUITE_POINTER, "properties")
+    G_PROPERTIES[G_PROPERTIES_LOOP].text = ""
+    CURRENT_PROPERTIES_POINTER = G_PROPERTIES[G_PROPERTIES_LOOP]
     printOutput()
-    
+
 
 def pSuite_property(resultfile, name, value):
-    global currentPropertiesPointer
-    global gProperties  
-    global gPropertiesLoop
-    
-    global gProperty
-    global gPropertyLoop
-    
-    gPropertyLoop  = gPropertyLoop+1    
-    gProperty[gPropertyLoop] = ET.SubElement(currentPropertiesPointer,"property")   
-    gProperty[gPropertyLoop].set('name',name)
-    gProperty[gPropertyLoop].set('value',value) 
+    """ set the properties of test suite """
+    global CURRENT_PROPERTIES_POINTER
+    global G_PROPERTIES
+    global G_PROPERTIES_LOOP
+
+    global G_PROPERTY
+    global G_PROPERTY_LOOP
+
+    G_PROPERTY_LOOP = G_PROPERTY_LOOP+1
+    G_PROPERTY[G_PROPERTY_LOOP] = ET.SubElement(CURRENT_PROPERTIES_POINTER, "property")
+    G_PROPERTY[G_PROPERTY_LOOP].set('name', name)
+    G_PROPERTY[G_PROPERTY_LOOP].set('value', value)
     printOutput()
-    
+
 
 def pSuite_testcase(resultfile, classname, name, time):
-    global currentTestSuitePointer
-    global currentTestCasePointer
-    
-    global gTestSuite
-    global gTestSuiteLoop
-    
-    global gTestCase
-    global gTestCaseLoop
-    
-    gTestCase[gTestCaseLoop] = ET.SubElement(currentTestSuitePointer,"testcase")    
-    gTestCase[gTestCaseLoop].set('classname',classname)
-    gTestCase[gTestCaseLoop].set('name',name)
-    gTestCase[gTestCaseLoop].set('time',time)
-    currentTestCasePointer = gTestCase[gTestCaseLoop]
+    """ set the attributes of test case """
+    global CURRENT_TESTSUITE_POINTER
+    global CURRENT_TESTCASE_POINTER
+
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+
+    global G_TESTCASE
+    global G_TESTCASE_LOOP
+
+    G_TESTCASE[G_TESTCASE_LOOP] = ET.SubElement(CURRENT_TESTSUITE_POINTER, "testcase")
+    G_TESTCASE[G_TESTCASE_LOOP].set('classname', classname)
+    G_TESTCASE[G_TESTCASE_LOOP].set('name', name)
+    G_TESTCASE[G_TESTCASE_LOOP].set('time', time)
+    CURRENT_TESTCASE_POINTER = G_TESTCASE[G_TESTCASE_LOOP]
     printOutput()
 
 
 def pSuite_testcase_failure(resultfile, msg='test failure', time='0', testCaseText=''):
-    global currentTestCasePointer
-    global gTestCase
-    global gTestCaseLoop
-    
-    testCaseStatus = ET.SubElement(currentTestCasePointer,"failure")
-    testCaseStatus.set('message',msg)
+    """  Computes failed case status with message and update on case duration in
+         test suite """
+    global CURRENT_TESTCASE_POINTER
+    global G_TESTCASE
+    global G_TESTCASE_LOOP
+
+    testCaseStatus = ET.SubElement(CURRENT_TESTCASE_POINTER, "failure")
+    testCaseStatus.set('message', msg)
     testCaseStatus.text = testCaseText
     update_tc_duration(time)
-    
 
 
 def pSuite_testcase_skip(resultfile):
-    global currentTestCasePointer
-    global gTestCase
-    global gTestCaseLoop
-    
-    testCaseStatus = ET.SubElement(currentTestCasePointer,"skipped")    
-    testCaseStatus.text = ""
+    """ Computes skipped case status in test suite """
+    global CURRENT_TESTCASE_POINTER
+    global G_TESTCASE
+    global G_TESTCASE_LOOP
+
+    testCaseStatus = ET.SubElement(CURRENT_TESTCASE_POINTER, "skipped")
     printOutput()
-    
-    #resultfile.write('<skipped/>\n')
-    #resultfile.flush()
+
+    # resultfile.write('<skipped/>\n')
+    # resultfile.flush()
+
 
 def pSuite_testcase_error(resultfile, msg='test error', time='0', testCaseText=''):
-    global currentTestCasePointer
-    global gTestCase
-    global gTestCaseLoop
-    
-    testCaseStatus = ET.SubElement(currentTestCasePointer,"error")
-    testCaseStatus.set('message',msg)
+    """ Computes error case status with message and update on case duration in
+        suite """
+    global CURRENT_TESTCASE_POINTER
+    global G_TESTCASE
+    global G_TESTCASE_LOOP
+
+    testCaseStatus = ET.SubElement(CURRENT_TESTCASE_POINTER, "error")
+    testCaseStatus.set('message', msg)
     testCaseStatus.text = testCaseText
     update_tc_duration(time)
 
 
 def update_tc_duration(time):
-    """ """
-    global root
-    global currentTestCasePointer
-    
-    global gTestSuite
-    global gTestSuiteLoop
-    currentTestCasePointer.set('time',time)
+    """ Updates the case duration"""
+    global ROOT
+    global CURRENT_TESTCASE_POINTER
+
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+    CURRENT_TESTCASE_POINTER.set('time', time)
     printOutput()
-    
+
+
 def update_suite_duration(time):
-    """ """
-    global root
-    global currentTestSuitePointer
-    
-    global gTestSuite
-    global gTestSuiteLoop
-    
-    currentTestSuitePointer.set('time',time)
-    printOutput()   
+    """ Updates the suite duration """
+    global ROOT
+    global CURRENT_TESTSUITE_POINTER
+
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+
+    CURRENT_TESTSUITE_POINTER.set('time', time)
+    printOutput()
+
 
 def pSuite_update_suite_attributes(resultfile, errors, skipped, tests, failures, time='0'):
-    global root
-    global currentTestSuitePointer
-    
-    global gTestSuite
-    global gTestSuiteLoop
-    
-    currentTestSuitePointer.set('errors',errors)
-    currentTestSuitePointer.set('skipped',skipped)
-    currentTestSuitePointer.set('tests',tests)
-    currentTestSuitePointer.set('failures',failures)
-    currentTestSuitePointer.set('time',time)
+    """ Updates the suite attributes """
+    global ROOT
+    global CURRENT_TESTSUITE_POINTER
+
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+
+    CURRENT_TESTSUITE_POINTER.set('errors', errors)
+    CURRENT_TESTSUITE_POINTER.set('skipped', skipped)
+    CURRENT_TESTSUITE_POINTER.set('tests', tests)
+    CURRENT_TESTSUITE_POINTER.set('failures', failures)
+    CURRENT_TESTSUITE_POINTER.set('time', time)
     printOutput()
+
 
 def pSuite_update_suite_tests(tests):
-    global root
-    global currentTestSuitePointer
-    
-    global gTestSuite
-    global gTestSuiteLoop
-    
-    currentTestSuitePointer.set('tests',tests)
+    """ Updates the suite tests"""
+    global ROOT
+    global CURRENT_TESTSUITE_POINTER
+
+    global G_TESTSUITE
+    global G_TESTSUITE_LOOP
+
+    CURRENT_TESTSUITE_POINTER.set('tests', tests)
     printOutput()
 
-def pSuite_report_suite_result(resultfile): 
-    tree = ET.ElementTree(root) 
+
+def pSuite_report_suite_result(resultfile):
+    """Reports the suite result to the suite result xml file """
+    tree = ET.ElementTree(ROOT)
     tree.write(resultfile)
+
 
 def get_suite_timestamp():
     """Returns the date-time stamp for the start of testsuite execution in JUnit format """
-    return datetime.datetime.now().strftime ("%Y-%m-%dT%H:%M:%S")
+    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
 
 def pSuite_report_suite_requirements(resultfile, requirement_id):
     """Reports the requirements of the suite to the suite result xml file """
-    pSuite_property(resultfile, 'requirement', requirement_id)     
+    pSuite_property(resultfile, 'requirement', requirement_id)
 
 
 def compute_testsuite_status(suite_status, tc_status, tc_impact):
-    """Computes the status of the testsuite based on the impact value for the testcase 
-    
+    """Computes the status of the testsuite based on the impact value for the testcase
+
     Arguments:
     1. tc_status = (bool) status of the executed testcase
     2. tc_impact = (string) impact   = tc_status will be used to compute testsuite_status
@@ -228,34 +245,33 @@ def compute_testsuite_status(suite_status, tc_status, tc_impact):
     """
 
     if tc_impact.upper() == 'IMPACT':
-        suite_status =  suite_status and tc_status
-        
+        suite_status = suite_status and tc_status
 
-    elif tc_impact.upper() == 'NOIMPACT': 
+    elif tc_impact.upper() == 'NOIMPACT':
         print_info('result of this testcase does not impact the testsuite status')
-    print(suite_status)
+    print_info(suite_status)
     return suite_status
 
 
-def report_testsuite_result(suite_repository, suite_status) :
+def report_testsuite_result(suite_repository, suite_status):
     """Reports the result of the testsuite executed
     Arguments:
     1. suite_repository    = (dict) dictionary caontaining all the data related to the testsuite
     2. suite_status        = (bool) status of the testsuite executed
     """
-    suite_resultfile = suite_repository['junit_resultfile'] 
-    print_info( "\n ****** TestSuite Result ******")
-    suite_status = {'TRUE': 'PASS', 'FALSE': 'FAIL', 'EXCEPTION': 'ERROR', 'ERROR': 'ERROR'}.get(str(suite_status).upper())
+    # suite_resultfile = suite_repository['junit_resultfile']
+    print_info("\n ****** TestSuite Result ******")
+    suite_status = {'TRUE': 'PASS', 'FALSE': 'FAIL', 'EXCEPTION': 'ERROR', 'ERROR': 'ERROR',
+                    'RAN': 'RAN'}.get(str(suite_status).upper())
     print_info("Testsuite:{0}  STATUS:{1}".format(suite_repository['suite_name'], suite_status))
-    #pSuite_report_suite_result(suite_resultfile)
-    print_info( "\n$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ END OF TEST SUITE $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$")
+    # pSuite_report_suite_result(suite_resultfile)
+    print_info("\n$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ END OF TEST SUITE $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$")
     return suite_status
-
 
 
 def get_path_from_xmlfile(element):
     """Gets the testcase/testsuite path  from the testsuite.xml/project.xml file """
-    
+
     path = xml_Utils.get_text_from_direct_child(element, 'path')
     if path is None or path is False:
         print_error("path cannot be empty check input xml file")
@@ -264,43 +280,46 @@ def get_path_from_xmlfile(element):
         path = path.strip()
     return path
 
+
 def get_data_file_at_suite_step(element, suite_repository):
     """Gets the testcase/testsuite path  from the testsuite.xml/project.xml file """
-    
-    
+
     if suite_repository["suite_exectype"].upper() == "ITERATIVE_SEQUENTIAL" \
-    or suite_repository["suite_exectype"].upper() == "ITERATIVE_PARALLEL":
+       or suite_repository["suite_exectype"].upper() == "ITERATIVE_PARALLEL":
         print_info("Suite exectype=iterative, so all testcases in the suite will use the suite datafile as their input datafile")
         data_file = suite_repository["data_file"]
-    else:    
+    else:
         data_file = xml_Utils.get_text_from_direct_child(element, 'InputDataFile')
     if data_file is None or data_file is False:
         data_file = None
     elif data_file is not None and data_file is not False:
         data_file = str(data_file).strip()
-    return data_file 
+    return data_file
+
 
 def get_runtype_from_xmlfile(element):
     """Gets the runtype value of a testcase from the testsuite.xml file """
-    
+
     runtype = xml_Utils.get_text_from_direct_child(element, 'runtype')
     if runtype is None or runtype is False:
-        runtype='sequential_keywords'
+        runtype = 'sequential_keywords'
     elif runtype is not None and runtype is not False:
         runtype = runtype.strip()
         supported_values = ['sequential_keywords', 'parallel_keywords']
         if runtype.lower() not in supported_values:
-            print_warning("unsupported value '{0}' provided for runtype, supported values are '{1}', case-insensitive".format(runtype, supported_values))
+            print_warning("unsupported value '{0}' provided for runtype, supported values are '{1}', case-insensitive"
+                          .format(runtype, supported_values))
             print_info("Hence using default value for runtype which is 'sequential_keywords'")
             runtype = 'sequential_keywords'
     return runtype
 
+
 def get_exectype_from_xmlfile(filepath):
     """Gets the exectype values for testcases from the testsuite.xml file """
-    
+
     exectype = xml_Utils.getChildAttributebyParentTag(filepath, 'Details', 'type', 'exectype')
     if exectype is None or exectype is False:
-        exectype='sequential_testcases'
+        exectype = 'sequential_testcases'
     elif exectype is not None and exectype is not False:
         exectype = exectype.strip()
         supported_values = ['sequential_testcases', 'parallel_testcases', 'run_until_fail', 'run_multiple', 'run_until_pass', "iterative_sequential",
@@ -310,5 +329,3 @@ def get_exectype_from_xmlfile(filepath):
             print_info("Hence using default value for exectype which is 'sequential_testcases'")
             exectype = 'sequential_testcases'
     return exectype
-
-

--- a/wftests/warrior_tests/testcases/framework_tests/tc_wtag_unit_tests.xml
+++ b/wftests/warrior_tests/testcases/framework_tests/tc_wtag_unit_tests.xml
@@ -85,7 +85,7 @@
             <onError action="next"/>
             <Description>Check if lab PC is current or need replacement</Description>
             <Execute ExecType="Yes"/>
-            <context>positive</context>
+            <context>negative</context>
             <impact>impact</impact>
             <Iteration_type type=""/>
         </step>
@@ -97,7 +97,7 @@
             <onError action="next"/>
             <Description>Check lab PC replacement Status</Description>
             <Execute ExecType="Yes"/>
-            <context>positive</context>
+            <context>negative</context>
             <impact>impact</impact>
             <runmode type="Standard" value=""/>
         </step>


### PR DESCRIPTION
Requirement:
Subject line of the email sent by Warrior will have the execution status, now it is always 'None' for project execution but it has to reflect the correct execution status.

Fix explanation:
Project status is computed in sequential/parallel suite(s) execution, possible status values are:

(i) ERROR(string) - for both error and exception
(ii) True(boolean)
(iii) False(boolean)
(iv) RAN(string)
In Suite/Case, the execution status values thus obtained are converted to corresponding strings (PASS/FAIL/ERROR) using dictionary and gets printed without being stored in a variable
in respective methods. But in project, the values after conversion are stored in a variable named project_status which results in reflection of project execution status as 'None' in
email subject. Therefore, removing the assignment which is not used.

Attached the regression logs and instructions for testing in Jira.

Edit - 04.06.2018 by ReshmaManohar

Included the below modifications,

Earlier, mockrun status 'RAN' was reflected as 'None' in mail for Case/Suite/Project. Resolved the same
by adding a key 'RAN' to resultconverted dict in email_utils.
Also mockrun execution result was 'None' for Suite/Project. Resolved it by adding a key 'RAN' to dict
in report_project_result method (project_driver.py) and report_testsuite_result
method (testsuite_utils.py) respectively.

Attached the logs in Jira.

PR for WarriorFramework repo : https://github.com/warriorframework/warriorframework/pull/410