### PR TITLE
WAR-1822 : The keyword 'send_commands_by_testdata_title_rownum' does not store the response into the data repository

### DIFF
--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -391,7 +391,7 @@ class WarriorCli(object):
                         pNote(save_msg2.format(pattern))
                     resp_key_list.append(dict(list(zip(keys, temp_resp_key_list))))
             else:
-                temp_resp_dict = {resp_ref: ""}
+                temp_resp_dict = {resp_ref: response}
                 resp_key_list.append(temp_resp_dict)
         else:
             temp_resp_dict = {resp_ref: ""}


### PR DESCRIPTION
Requirement:
Response of the keyword 'send_commands_by_testdata_title_rownum' keyword should be stored in data repository.This was working as expected till warrior-3.4.0.

Reason for the issue:
In _get_response_dict method (Framework/ClassUtils/WNetwork/warrior_cli_class.py), for the condition, resp_pat_req is None, empty string is provided as value for ' resp_ref ' key.

Fix Explanation:
Replaced the empty string which was provided as value for ' resp_ref ' key with the response value.

PR for WarriorFramework repo : https://github.com/warriorframework/warriorframework/pull/417

Attached the regression logs and instructions for testing in Jira.