### PR TITLE
WAR-1831: As a user, I need an option to set pseudo-terminal dimensions in connect keywords

### DIFF
--- a/warrior/Actions/CliActions/cli_actions.py
+++ b/warrior/Actions/CliActions/cli_actions.py
@@ -36,7 +36,7 @@ class CliActions(object):
 
     @mockready
     def connect(self, system_name, session_name=None, prompt=".*(%|#|\$)",
-                ip_type="ip", via_host=None, tuple_dimensions=None):
+                ip_type="ip", via_host=None, tuple_pty_dimensions=None):
         """
         This is a generic connect that can connect to ssh/telnet based
         on the conn_type provided by the user in the input datafile.
@@ -72,7 +72,7 @@ class CliActions(object):
             10.custom_keystroke = a keystroke that will be sent after the initial
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
-            11.dimensions = size of the pseudo-terminal specified as a
+            11.pty_dimensions = size of the pseudo-terminal specified as a
                 two-entry tuple (rows, columns), eg. (24, 80).
 
 
@@ -97,7 +97,7 @@ class CliActions(object):
             5. via_host = Name of the system in the data file to be used as an
                 intermediate system for establishing nested connections,
                 currently it is applicable only for SSH connections.
-            6. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+            6. tuple_pty_pty_dimensions(tuple) = size of the pseudo-terminal specified as a
                 two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
@@ -134,13 +134,14 @@ class CliActions(object):
 
             if conn_type is not False:
                 if conn_type == "ssh":
-                    result, output_dict = self.connect_ssh(call_system_name, session_name, prompt,
-                                                           ip_type, via_host=via_host,
-                                                           tuple_dimensions=tuple_dimensions)
+                    result, output_dict = \
+                     self.connect_ssh(call_system_name, session_name, prompt,
+                                      ip_type, via_host=via_host,
+                                      tuple_pty_dimensions=tuple_pty_dimensions)
                 elif conn_type == "telnet":
-                    result, output_dict = self.connect_telnet(call_system_name, session_name,
-                                                              ip_type,
-                                                              tuple_dimensions=tuple_dimensions)
+                    result, output_dict = \
+                     self.connect_telnet(call_system_name, session_name, ip_type,
+                                         tuple_pty_dimensions=tuple_pty_dimensions)
                 else:
                     pNote("<conn_type>={0} provided for '{1}' is  not "
                           "supported".format(conn_type, call_system_name), "error")
@@ -224,7 +225,7 @@ class CliActions(object):
     @mockready
     def connect_ssh(self, system_name, session_name=None, prompt=".*(%|#|\$)",
                     ip_type="ip", int_timeout=60, via_host=None,
-                    tuple_dimensions=None):
+                    tuple_pty_dimensions=None):
         """Connects to the ssh port of the the given system or subsystems
 
         :Datafile usage:
@@ -253,7 +254,7 @@ class CliActions(object):
             8. custom_keystroke = a keystroke that will be sent after the initial
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
-            9. dimensions = size of the pseudo-terminal specified as a
+            9. pty_dimensions = size of the pseudo-terminal specified as a
                 two-entry tuple(rows, columns), eg. (24, 80).
 
         :Arguments:
@@ -278,7 +279,7 @@ class CliActions(object):
             6. via_host(string) = name of the system in the data file to be
                 used as an intermediate system for establishing nested ssh
                 connections.
-            7. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+            7. tuple_pty_dimensions(tuple) = size of the pseudo-terminal specified as a
                 two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
@@ -311,7 +312,7 @@ class CliActions(object):
                                           [ip_type, 'ssh_port', 'username',
                                            'password', 'prompt', 'timeout',
                                            'conn_options', 'custom_keystroke',
-                                           'escape', 'dimensions'])
+                                           'escape', 'pty_dimensions'])
             # parse more things here
             pNote("system={0}, session={1}".format(call_system_name, session_name))
             session_id = get_session_id(call_system_name, session_name)
@@ -326,8 +327,8 @@ class CliActions(object):
                     credentials["prompt"] = prompt
                 if not credentials["timeout"]:
                     credentials["timeout"] = int_timeout
-                if not credentials['dimensions']:
-                    credentials["dimensions"] = tuple_dimensions
+                if not credentials["pty_dimensions"]:
+                    credentials["pty_dimensions"] = tuple_pty_dimensions
                 credentials["password"] = decrypt(credentials["password"])
 
                 if ip_type != "ip":
@@ -398,7 +399,7 @@ class CliActions(object):
 
     @mockready
     def connect_telnet(self, system_name, session_name=None, ip_type="ip",
-                       int_timeout=60, tuple_dimensions=None):
+                       int_timeout=60, tuple_pty_dimensions=None):
         """Connects to the telnet port of the the given system and/or subsystem and creates a
         pexpect session object for the system
 
@@ -432,7 +433,7 @@ class CliActions(object):
             8. custom_keystroke = a keystroke that will be sent after the initial\
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
-            9. dimensions = size of the pseudo-terminal specified as a
+            9. pty_dimensions = size of the pseudo-terminal specified as a
                 two-entry tuple(rows, columns), eg. (24, 80).
 
         :Arguments:
@@ -453,7 +454,7 @@ class CliActions(object):
             3. ip_type(string) = type of the ip address(ip, ipv4, ipv6, dns, etc).
             4. int_timeout(int) = use this to set timeout value for commands
                 issued in this session.
-            5. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+            5. tuple_pty_dimensions(tuple) = size of the pseudo-terminal specified as a
                 two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
@@ -488,7 +489,7 @@ class CliActions(object):
                                           [ip_type, 'telnet_port', 'username',
                                            'prompt', 'password', 'timeout',
                                            'conn_options', 'custom_keystroke',
-                                           'escape', 'dimensions'])
+                                           'escape', 'pty_dimensions'])
             pNote("system={0}, session={1}".format(call_system_name, session_name))
             Utils.testcase_Utils.pNote(Utils.file_Utils.getDateTime())
             session_id = get_session_id(call_system_name, session_name)
@@ -502,8 +503,8 @@ class CliActions(object):
                                                                                     session_id))
                 if not credentials["timeout"]:
                     credentials["timeout"] = int_timeout
-                if not credentials['dimensions']:
-                    credentials["dimensions"] = tuple_dimensions
+                if not credentials["pty_dimensions"]:
+                    credentials["pty_dimensions"] = tuple_pty_dimensions
                 if credentials["password"]:
                     credentials["password"] = decrypt(credentials["password"])
 

--- a/warrior/Actions/CliActions/cli_actions.py
+++ b/warrior/Actions/CliActions/cli_actions.py
@@ -36,7 +36,7 @@ class CliActions(object):
 
     @mockready
     def connect(self, system_name, session_name=None, prompt=".*(%|#|\$)",
-                ip_type="ip", via_host=None):
+                ip_type="ip", via_host=None, tuple_dimensions=None):
         """
         This is a generic connect that can connect to ssh/telnet based
         on the conn_type provided by the user in the input datafile.
@@ -72,6 +72,8 @@ class CliActions(object):
             10.custom_keystroke = a keystroke that will be sent after the initial
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
+            11.dimensions = size of the pseudo-terminal specified as a
+                two-entry tuple (rows, columns), eg. (24, 80).
 
 
         :Arguments:
@@ -95,6 +97,8 @@ class CliActions(object):
             5. via_host = Name of the system in the data file to be used as an
                 intermediate system for establishing nested connections,
                 currently it is applicable only for SSH connections.
+            6. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+                two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
             1. status(bool)= True / False.
@@ -131,10 +135,12 @@ class CliActions(object):
             if conn_type is not False:
                 if conn_type == "ssh":
                     result, output_dict = self.connect_ssh(call_system_name, session_name, prompt,
-                                                           ip_type, via_host=via_host)
+                                                           ip_type, via_host=via_host,
+                                                           tuple_dimensions=tuple_dimensions)
                 elif conn_type == "telnet":
                     result, output_dict = self.connect_telnet(call_system_name, session_name,
-                                                              ip_type)
+                                                              ip_type,
+                                                              tuple_dimensions=tuple_dimensions)
                 else:
                     pNote("<conn_type>={0} provided for '{1}' is  not "
                           "supported".format(conn_type, call_system_name), "error")
@@ -217,7 +223,8 @@ class CliActions(object):
 
     @mockready
     def connect_ssh(self, system_name, session_name=None, prompt=".*(%|#|\$)",
-                    ip_type="ip", int_timeout=60, via_host=None):
+                    ip_type="ip", int_timeout=60, via_host=None,
+                    tuple_dimensions=None):
         """Connects to the ssh port of the the given system or subsystems
 
         :Datafile usage:
@@ -246,6 +253,8 @@ class CliActions(object):
             8. custom_keystroke = a keystroke that will be sent after the initial
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
+            9. dimensions = size of the pseudo-terminal specified as a
+                two-entry tuple(rows, columns), eg. (24, 80).
 
         :Arguments:
             1. system_name (string) = This can be name of the\
@@ -269,6 +278,8 @@ class CliActions(object):
             6. via_host(string) = name of the system in the data file to be
                 used as an intermediate system for establishing nested ssh
                 connections.
+            7. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+                two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
             1. status(bool)= True / False.
@@ -299,7 +310,8 @@ class CliActions(object):
             credentials = get_credentials(self.datafile, call_system_name,
                                           [ip_type, 'ssh_port', 'username',
                                            'password', 'prompt', 'timeout',
-                                           'conn_options', 'custom_keystroke', 'escape'])
+                                           'conn_options', 'custom_keystroke',
+                                           'escape', 'dimensions'])
             # parse more things here
             pNote("system={0}, session={1}".format(call_system_name, session_name))
             session_id = get_session_id(call_system_name, session_name)
@@ -314,6 +326,8 @@ class CliActions(object):
                     credentials["prompt"] = prompt
                 if not credentials["timeout"]:
                     credentials["timeout"] = int_timeout
+                if not credentials['dimensions']:
+                    credentials["dimensions"] = tuple_dimensions
                 credentials["password"] = decrypt(credentials["password"])
 
                 if ip_type != "ip":
@@ -383,7 +397,8 @@ class CliActions(object):
         return status, output_dict
 
     @mockready
-    def connect_telnet(self, system_name, session_name=None, ip_type="ip", int_timeout=60):
+    def connect_telnet(self, system_name, session_name=None, ip_type="ip",
+                       int_timeout=60, tuple_dimensions=None):
         """Connects to the telnet port of the the given system and/or subsystem and creates a
         pexpect session object for the system
 
@@ -417,6 +432,8 @@ class CliActions(object):
             8. custom_keystroke = a keystroke that will be sent after the initial\
                 timeout, in case of server require a keystroke to show any prompt.
                 Default is the enter key
+            9. dimensions = size of the pseudo-terminal specified as a
+                two-entry tuple(rows, columns), eg. (24, 80).
 
         :Arguments:
             1. system_name (string) = This can be name of the\
@@ -434,8 +451,10 @@ class CliActions(object):
                     system_name="system_name[all]".
             2. session_name(string) = name of the session to the system
             3. ip_type(string) = type of the ip address(ip, ipv4, ipv6, dns, etc).
-            4. timeout(int) = use this to set timeout value for commands\
+            4. int_timeout(int) = use this to set timeout value for commands
                 issued in this session.
+            5. tuple_dimensions(tuple) = size of the pseudo-terminal specified as a
+                two-entry tuple(rows, columns), eg. (24, 80).
 
         :Returns:
             1. status(bool)= True / False.
@@ -467,8 +486,9 @@ class CliActions(object):
                 call_system_name += "[{}]".format(subsystem_name)
             credentials = get_credentials(self.datafile, call_system_name,
                                           [ip_type, 'telnet_port', 'username',
-                                           'prompt', 'password', 'timeout', 'conn_options',
-                                           'custom_keystroke', 'escape'])
+                                           'prompt', 'password', 'timeout',
+                                           'conn_options', 'custom_keystroke',
+                                           'escape', 'dimensions'])
             pNote("system={0}, session={1}".format(call_system_name, session_name))
             Utils.testcase_Utils.pNote(Utils.file_Utils.getDateTime())
             session_id = get_session_id(call_system_name, session_name)
@@ -482,6 +502,8 @@ class CliActions(object):
                                                                                     session_id))
                 if not credentials["timeout"]:
                     credentials["timeout"] = int_timeout
+                if not credentials['dimensions']:
+                    credentials["dimensions"] = tuple_dimensions
                 if credentials["password"]:
                     credentials["password"] = decrypt(credentials["password"])
 

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -857,26 +857,26 @@ class WarriorCli(object):
 
     @staticmethod
     def pexpect_spawn_with_env(pexpect_obj, command, timeout, escape=False,
-                               env=None, dimensions=None):
-        """ spawn a pexpect object with environment & dimensions variables """
+                               env=None, pty_dimensions=None):
+        """ spawn a pexpect object with environment & pty_dimensions variables """
 
         if not(str(escape).lower() == "yes" or str(escape).lower() == "true"):
             env = {}
 
-        sendDimensions = False
-        if dimensions is not None:
+        sendPtydimensions = False
+        if pty_dimensions is not None:
             # 'dimensions' argument is supported in pexpect version 4.0 and above
             if LooseVersion(pexpect_obj.__version__) >= LooseVersion('4.0'):
-                sendDimensions = True
+                sendPtydimensions = True
             else:
                 print_warning("Setting pseudo-terminal dimensions is not supported in "
                               "pexpect versions less than 4.0(installed pexpect "
                               "version: {}), 'dimensions' value will be default "
                               "to None".format(pexpect_obj.__version__))
 
-        if sendDimensions is True:
+        if sendPtydimensions is True:
             child = pexpect_obj.spawn(command, timeout=int(timeout), env=env,
-                                      dimensions=dimensions)
+                                      dimensions=pty_dimensions)
         else:
             child = pexpect_obj.spawn(command, timeout=int(timeout), env=env)
 
@@ -1271,8 +1271,9 @@ class PexpectConnect(object):
                 10. escape(string) = true/false(to escape color codes by
                                      setting TERM as dump)
                 11. conn_type = session type(ssh/telnet)
-                12. dimensions(tuple) = size of the pseudo-terminal specified
-                                        as a two-entry tuple(rows, columns)
+                12. pty_dimensions(tuple) = size of the pseudo-terminal
+                                            specified as a two-entry
+                                            tuple(rows, columns)
          """
 
         self.pexpect = None
@@ -1294,19 +1295,20 @@ class PexpectConnect(object):
         self.conn_options = credentials.get('conn_options', '')
         self.custom_keystroke = credentials.get('custom_keystroke', '')
         self.escape = credentials.get('escape', False)
-        self.dimensions = credentials.get('dimensions', None)
-        # convert dimension value from string to tuple
-        if self.dimensions and isinstance(self.dimensions, str):
-            err_msg = ("Invalid value '{}' given for dimensions argument, it "
-                       "only accepts tuple value(It will be default to None).")
+        self.pty_dimensions = credentials.get('pty_dimensions', None)
+        # convert pty_dimensions value from string to tuple
+        if self.pty_dimensions and isinstance(self.pty_dimensions, str):
+            err_msg = ("Invalid value '{}' given for pty_dimensions "
+                       "argument, it only accepts tuple value"
+                       "(It will be default to None).")
             try:
-                self.dimensions = ast.literal_eval(self.dimensions)
+                self.pty_dimensions = ast.literal_eval(self.pty_dimensions)
             except Exception:
-                print_warning(err_msg.format(self.dimensions))
+                print_warning(err_msg.format(self.pty_dimensions))
             else:
-                if not isinstance(self.dimensions, tuple):
-                    print_warning(err_msg.format(self.dimensions))
-                    self.dimensions = None
+                if not isinstance(self.pty_dimensions, tuple):
+                    print_warning(err_msg.format(self.pty_dimensions))
+                    self.pty_dimensions = None
 
     def __import_pexpect(self):
         """Import the pexpect module """
@@ -1354,7 +1356,7 @@ class PexpectConnect(object):
                                                   self.timeout,
                                                   escape=self.escape,
                                                   env={"TERM": "dumb"},
-                                                  dimensions=self.dimensions)
+                                                  pty_dimensions=self.pty_dimensions)
 
         child.logfile = sys.stdout
 
@@ -1417,7 +1419,7 @@ class PexpectConnect(object):
                                                               self.timeout,
                                                               escape=self.escape,
                                                               env={"TERM": "dumb"},
-                                                              dimensions=self.dimensions)
+                                                              pty_dimensions=self.pty_dimensions)
                     print_debug("ReconnectSSH: cmd = %s" % command)
         except Exception as exception:
             print_exception(exception)
@@ -1446,7 +1448,7 @@ class PexpectConnect(object):
                                                   self.timeout,
                                                   env={"TERM": "dumb"},
                                                   escape=self.escape,
-                                                  dimensions=self.dimensions)
+                                                  pty_dimensions=self.pty_dimensions)
 
         try:
             child.logfile = open(self.logfile, "ab")

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -19,6 +19,8 @@ import subprocess
 import getpass
 import xml
 import Tools
+import ast
+from distutils.version import LooseVersion
 from Framework import Utils
 from Framework.Utils.print_Utils import print_info, print_debug,\
  print_warning, print_exception, print_error
@@ -855,15 +857,29 @@ class WarriorCli(object):
 
     @staticmethod
     def pexpect_spawn_with_env(pexpect_obj, command, timeout, escape=False,
-                               env=None):
+                               env=None, dimensions=None):
+        """ spawn a pexpect object with environment & dimensions variables """
 
-        """ spawn a pexpect object with environment variable """
-        if env is None:
+        if not(str(escape).lower() == "yes" or str(escape).lower() == "true"):
             env = {}
-        if str(escape).lower() == "yes" or str(escape).lower() == "true":
-            child = pexpect_obj.spawn(command, timeout=int(timeout), env=env)
+
+        sendDimensions = False
+        if dimensions is not None:
+            # 'dimensions' argument is supported in pexpect version 4.0 and above
+            if LooseVersion(pexpect_obj.__version__) >= LooseVersion('4.0'):
+                sendDimensions = True
+            else:
+                print_warning("Setting pseudo-terminal dimensions is not supported in "
+                              "pexpect versions less than 4.0(installed pexpect "
+                              "version: {}), 'dimensions' value will be default "
+                              "to None".format(pexpect_obj.__version__))
+
+        if sendDimensions is True:
+            child = pexpect_obj.spawn(command, timeout=int(timeout), env=env,
+                                      dimensions=dimensions)
         else:
-            child = pexpect_obj.spawn(command, timeout=int(timeout))
+            child = pexpect_obj.spawn(command, timeout=int(timeout), env=env)
+
         return child
 
     @staticmethod
@@ -1255,6 +1271,8 @@ class PexpectConnect(object):
                 10. escape(string) = true/false(to escape color codes by
                                      setting TERM as dump)
                 11. conn_type = session type(ssh/telnet)
+                12. dimensions(tuple) = size of the pseudo-terminal specified
+                                        as a two-entry tuple(rows, columns)
          """
 
         self.pexpect = None
@@ -1276,6 +1294,19 @@ class PexpectConnect(object):
         self.conn_options = credentials.get('conn_options', '')
         self.custom_keystroke = credentials.get('custom_keystroke', '')
         self.escape = credentials.get('escape', False)
+        self.dimensions = credentials.get('dimensions', None)
+        # convert dimension value from string to tuple
+        if self.dimensions and isinstance(self.dimensions, str):
+            err_msg = ("Invalid value '{}' given for dimensions argument, it "
+                       "only accepts tuple value(It will be default to None).")
+            try:
+                self.dimensions = ast.literal_eval(self.dimensions)
+            except Exception:
+                print_warning(err_msg.format(self.dimensions))
+            else:
+                if not isinstance(self.dimensions, tuple):
+                    print_warning(err_msg.format(self.dimensions))
+                    self.dimensions = None
 
     def __import_pexpect(self):
         """Import the pexpect module """
@@ -1321,7 +1352,9 @@ class PexpectConnect(object):
         print_debug("connectSSH: cmd = %s" % command)
         child = WarriorCli.pexpect_spawn_with_env(self.pexpect, command,
                                                   self.timeout,
-                                                  env={"TERM": "dumb"})
+                                                  escape=self.escape,
+                                                  env={"TERM": "dumb"},
+                                                  dimensions=self.dimensions)
 
         child.logfile = sys.stdout
 
@@ -1380,8 +1413,11 @@ class PexpectConnect(object):
                     print_debug("SSH Host Key is changed - Remove it from "
                                 "known_hosts file : cmd = %s" % cmd)
                     subprocess.call(cmd, shell=True)
-                    child = self.pexpect.spawn(command,
-                                               timeout=int(self.timeout))
+                    child = WarriorCli.pexpect_spawn_with_env(self.pexpect, command,
+                                                              self.timeout,
+                                                              escape=self.escape,
+                                                              env={"TERM": "dumb"},
+                                                              dimensions=self.dimensions)
                     print_debug("ReconnectSSH: cmd = %s" % command)
         except Exception as exception:
             print_exception(exception)
@@ -1408,7 +1444,9 @@ class PexpectConnect(object):
 
         child = WarriorCli.pexpect_spawn_with_env(self.pexpect, command,
                                                   self.timeout,
-                                                  env={"TERM": "dumb"})
+                                                  env={"TERM": "dumb"},
+                                                  escape=self.escape,
+                                                  dimensions=self.dimensions)
 
         try:
             child.logfile = open(self.logfile, "ab")


### PR DESCRIPTION
Add an option to set the dimensions of the pseudo-terminal(created by the pexpect in spawn class) in connect keywords.

Test instructions, regression results and other details are in Jira ticket.

py2 PR - https://github.com/warriorframework/warriorframework/pull/421