### PR TITLE
WAR-1844 : verify_response keyword in rest failing even for correct jsonpath

### DIFF
--- a/warrior/Framework/ClassUtils/json_utils_class.py
+++ b/warrior/Framework/ClassUtils/json_utils_class.py
@@ -248,7 +248,7 @@ class JsonUtils(object):
         status = True
         json_response = json.loads(response)
         for index, jsonpath in enumerate(list_of_jsonpath):
-            json_path = jsonpath.strip("jsonpath=")
+            json_path = jsonpath.strip().replace("jsonpath=", "")
             value = self.get_value_for_nested_key(json_response, json_path)
             # Equality_match: Check if the expected response is equal to API response
             match = True if value == list_of_expected_api_responses[index] else False

--- a/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
+++ b/wftests/warrior_tests/testcases/rest_functional_tests/tc_rest_verify_content_response.xml
@@ -199,5 +199,55 @@
 			<context>negative</context>
 			<impact>impact</impact>
 		</step>
+		<step Driver="rest_driver" Keyword="perform_http_get" TS="15">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="url" value="http://httpbin.org/response-headers?json1=string&amp;key2=value"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step tests the GET capability of REST</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="16">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="string"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=json1"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="17">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="val.*"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=key2"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Regex search - Pass)</Description>
+			<Execute ExecType="Yes"/>
+			<context>positive</context>
+			<impact>impact</impact>
+		</step>
+		<step Driver="rest_driver" Keyword="verify_response" TS="18">
+			<Arguments>
+				<argument name="system_name" value="http_bin_1"/>
+				<argument name="expected_api_response" value="value"/>
+				<argument name="expected_response_type" value="json"/>
+				<argument name="comparison_mode" value="jsonpath=json1"/>
+			</Arguments>
+			<onError action="next"/>
+			<Description>This step verifies the API response with the expected API response(Fail scenario)</Description>
+			<Execute ExecType="Yes"/>
+			<context>negative</context>
+			<impact>impact</impact>
+		</step>
 	</Steps>
 </Testcase>


### PR DESCRIPTION
Issue :
1. In strip() method,the characters in the specified string(the string that needs to be removed) will be stripped from both the ends of the string.
2. In compare_json_using_jsonpath method (json_utils_class), the strip() method provided to remove 'jsonpath=', also removes characters in trailing end of string, if it finds the same characters as in 'jsonpath='.
(i.e) strip('jsonpath=') in "jsonpath=admin-status" gives the result as 'dmin-statu' instead of admin-status.
This resulted in an error "doesn't match or available in the actual response value None", as the key is not present

Fix Explanation:
Replaced the strip(string) with strip().replace(string, '')

Added the regression logs and instructions for testing in Jira.

PR for WarriorFramework repo : https://github.com/warriorframework/warriorframework/pull/424