### PR TITLE
WAR-1928:Handle session timeout changes in pexpect 4.x for connect/send keywords 

### DIFF
--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -1600,6 +1600,7 @@ class PexpectConnect(object):
                                 format(Utils.datetime_utils.
                                        get_current_timestamp(),
                                        end_prompt)
+                            excep_msg = "EXCEPTION !! Command Timed Out"
                             break
                         else:
                             continue
@@ -1607,7 +1608,12 @@ class PexpectConnect(object):
                 print_exception(exception)
             else:
                 response = self.target_host.before.decode('utf-8')
-                response = response + self.target_host.after.decode('utf-8')
+                # prints an error message, if the end prompt is not received
+                # even after 60 seconds wait time
+                if self.target_host.after == self.pexpect.TIMEOUT:
+                    pNote(excep_msg, 'error')
+                else:
+                    response = response + self.target_host.after.decode('utf-8')
                 pNote("Response:\n{0}\n".format(response))
                 pNote(msg, "debug")
                 if status is True:

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -1607,8 +1607,8 @@ class PexpectConnect(object):
                 print_exception(exception)
             else:
                 response = self.target_host.before.decode('utf-8')
-                # When the command gets timed out, the timeout exception is
-                # raised which will be saved to the after of spawn object
+                # When the command gets timed out, the pexpect.TIMEOUT exception
+                # will be raised and it is set to the after property of spawn object
                 if self.target_host.after == self.pexpect.TIMEOUT:
                     pNote("EXCEPTION !! Command Timed Out", 'error')
                 else:

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -1600,7 +1600,6 @@ class PexpectConnect(object):
                                 format(Utils.datetime_utils.
                                        get_current_timestamp(),
                                        end_prompt)
-                            excep_msg = "EXCEPTION !! Command Timed Out"
                             break
                         else:
                             continue
@@ -1611,7 +1610,7 @@ class PexpectConnect(object):
                 # prints an error message, if the end prompt is not received
                 # even after 60 seconds wait time
                 if self.target_host.after == self.pexpect.TIMEOUT:
-                    pNote(excep_msg, 'error')
+                    pNote("EXCEPTION !! Command Timed Out", 'error')
                 else:
                     response = response + self.target_host.after.decode('utf-8')
                 pNote("Response:\n{0}\n".format(response))

--- a/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
+++ b/warrior/Framework/ClassUtils/WNetwork/warrior_cli_class.py
@@ -1607,8 +1607,8 @@ class PexpectConnect(object):
                 print_exception(exception)
             else:
                 response = self.target_host.before.decode('utf-8')
-                # prints an error message, if the end prompt is not received
-                # even after 60 seconds wait time
+                # When the command gets timed out, the timeout exception is
+                # raised which will be saved to the after of spawn object
                 if self.target_host.after == self.pexpect.TIMEOUT:
                     pNote("EXCEPTION !! Command Timed Out", 'error')
                 else:


### PR DESCRIPTION
Existing issue:
1. In connect and send keywords, we use pexpect.TIMEOUT to handle timeout exceptions. But this is not supported for versions of pexpect > = 4.0, in which pexpect.TIMEOUT is replaced with pexpect.exceptions.TIMEOUT
2. If the session timed out because of invalid prompt or if the prompt is not received even after 60 sec wait, the exception(<class 'pexpect.exceptions.TIMEOUT'>) is raised which gets converted to string and added with the response.

Fix Explanation:
1. Removed the timeout exception string from the response, which gets added to response when the prompt is not received.
2. Included an error message, to indicate the user that the command has timed out.

PR for WarriorFramework repo : https://github.com/warriorframework/warriorframework/pull/434
Adding regression logs and instructions for testing in Jira.