### PR TITLE
WAR-2048: Integrate django rest framework into Warrior-Django

### DIFF
--- a/katana/wui/settings.py
+++ b/katana/wui/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'wui.core',
     'native.wapp_management',
     'native.wappstore',
@@ -79,6 +80,18 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'wui.wsgi.application'
+
+# Django Rest Framework
+# https://www.django-rest-framework.org/api-guide/settings/
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+}
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases


### PR DESCRIPTION
Add Django-rest-framework, requiring basic authentication.

Try out by adding the api_view decorator or the APIView from https://www.django-rest-framework.org/api-guide/views/.