### PR TITLE
WAR-1893 LDAP: save user attributes fetched from external authentication ...

### DIFF
--- a/katana/wui/settings.py
+++ b/katana/wui/settings.py
@@ -12,6 +12,12 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 from . import settings_logging
+try:
+    import ldap
+    from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
+except Exception as err:
+    print("Please install django auth ldap to authenticate against ldap")
+    print("Error while importing django auth ldap: \n", err)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -122,7 +128,6 @@ AUTHENTICATION_BACKENDS = (
 
 MULTI_USER_SUPPORT = False
 USER_HOME_DIR_TEMPLATE = None
-
 
 
 # Password validation

--- a/katana/wui/users/models.py
+++ b/katana/wui/users/models.py
@@ -14,15 +14,13 @@ limitations under the License.
 # -*- coding: utf-8 -*-
 
 import logging
-from django.db import models
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser, Group, BaseUserManager
-from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.db import models
 from django.utils import timezone
 
 # Public  Constants
 GROUP_WARRIOR_USERS = 'Warrior Users'  # Name for Warrior Users Group
-BACKGROUND_USER_EXPIRY_CHECK = 60  # Seconds
 
 # Private Constants
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +28,13 @@ _LOGGER = logging.getLogger(__name__)
 
 class User(AbstractUser):
     """
-    Custom Warrior User Class
+    Custom Warrior User Class.
+
+    Customizations include:
+    * Addition of 'expires' field and expired() method.
+    * Adds user to a group named Warrior Users (name accessible through the GROUP_WARRIOR_USERS global) on creation.
+    * Adds user to groups imported from LDAP mapped using the setting AUTH_LDAP_GROUP_MAPPING.
+        * AUTH_LDAP_GROUP_MAPPING is a dictionary with entries of the form "LDAP group DN" : "Group Name".
     """
     # Add custom user fields here
     expires = models.DateTimeField(verbose_name="User Expiry Date", null=True, blank=True)
@@ -43,19 +47,43 @@ class User(AbstractUser):
         expires = self.expires
         now = timezone.now()
         if expires and expires < now:
+            self.active = False
+            self.save()
             return True
         return False
 
+    def save(self, *args, **kwargs):
+        """
+        Over-ridden save method for Warrior User.
+        Adds saved user to GROUP_WARRIOR_USERS on creation.
+        Adds saved user to mapped groups from LDAP using the setting AUTH_LDAP_GROUP_MAPPING,
+        assuming django-auth-ldap is also setup correctly.
+        :param args: Same as AbstractUser args
+        :param kwargs: Same as AbstractUser kwargs
+        :return: Same as AbstractUser
+        """
+        created = False
+        if not self.pk:
+            created = True
 
-@receiver(post_save, sender=User)
-def create_user_profile(sender, instance, created, **kwargs):
-    """
-    Add all created users to the base Warrior Users Group
-    :return:
-    """
-    if created:
-        try:
-            instance.groups.add(Group.objects.get(name=GROUP_WARRIOR_USERS))
-        except Exception as ex:
-            Group.objects.get_or_create(name=GROUP_WARRIOR_USERS)
-            instance.groups.add(Group.objects.get(name=GROUP_WARRIOR_USERS))
+        super(AbstractUser, self).save()
+
+        # Add to Warrior Users group on creation
+        if created:
+            try:
+                group, x = Group.objects.get_or_create(name=GROUP_WARRIOR_USERS)
+                self.groups.add(group)
+            except Exception as ex:
+                _LOGGER.error("Failed to add {} to group {}".format(self.username, GROUP_WARRIOR_USERS))
+                _LOGGER.debug("Exception thrown while adding group {} to user {}\n{}".format(GROUP_WARRIOR_USERS, self.username, ex))
+        # Map LDAP roles if applicable
+        if hasattr(settings, "AUTH_LDAP_GROUP_MAPPING") and hasattr(self, 'ldap_user'):
+            try:
+                mapping = getattr(settings, "AUTH_LDAP_GROUP_MAPPING", {})
+                for ldap, django in mapping.items():
+                    if ldap in self.ldap_user.group_dns:
+                        group, x = Group.objects.get_or_create(name=django)
+                        self.groups.add(group)
+            except Exception as ex:
+                _LOGGER.error("Failed to add {} to groups based on LDAP mapping".format(self.username))
+                _LOGGER.debug("Exception thrown while adding LDAP-mapped groups to user {}\n{}".format(self.username, ex))


### PR DESCRIPTION
Django-auth-ldap already takes care of mapping attributes through AUTH_LDAP_USER_ATTR_MAP and mapping user flags to LDAP groups via AUTH_LDAP_USER_FLAGS_BY_GROUP, but it does not provide a similar function for adding Groups to Users from LDAP groups. Therefore, AUTH_LDAP_GROUP_MAPPING has been introduced on our custom User model to handle this case.

If we ever change our LDAP library, then this code will also need to be changed. In the future, we may want to look into writing a custom LDAP utility so that LDAP settings can be entered through a UI instead of written o the settings.py. 